### PR TITLE
Add tests

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -193,7 +193,8 @@ async function run() {
 
   let resultsAccumulator = [];
   for (let relativeFilePath of filesToLint) {
-    let resolvedFilePath = path.resolve(relativeFilePath);
+    // on Windows the attempt to resolve the '/dev/stdin' doesn't return '/dev/stdin', hence explicit check
+    let resolvedFilePath = relativeFilePath === STDIN ? STDIN : path.resolve(relativeFilePath);
     let filePath = resolvedFilePath === STDIN ? options.filename || '' : relativeFilePath;
     let moduleId = filePath.slice(0, -4);
     let messages = await lintFile(linter, filePath, resolvedFilePath, moduleId, options.fix);

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -2,6 +2,9 @@
 const { readFileSync } = require('fs');
 
 const execa = require('execa');
+const fs = require('fs');
+const path = require('path');
+
 const Project = require('../helpers/fake-project');
 const setupEnvVar = require('../helpers/setup-env-var');
 
@@ -145,15 +148,11 @@ describe('ember-template-lint executable', function () {
     });
 
     describe('given no path', function () {
-      // TOFIX on windows
-      if (process.platform === 'win32') {
-        return;
-      }
-
       it('should print errors', async function () {
         setProjectConfigForErrors();
-        let result = await run(['<', 'app/templates/application.hbs'], {
-          shell: true,
+        let result = await run([], {
+          shell: false,
+          input: fs.readFileSync(path.resolve('app/templates/application.hbs')),
         });
 
         expect(result.exitCode).toEqual(1);
@@ -192,12 +191,10 @@ describe('ember-template-lint executable', function () {
     describe('given no path with --filename', function () {
       it('should print errors', async function () {
         setProjectConfigForErrors();
-        let result = await run(
-          ['--filename', 'app/templates/application.hbs', '<', 'app/templates/application.hbs'],
-          {
-            shell: true,
-          }
-        );
+        let result = await run(['--filename', 'app/templates/application.hbs'], {
+          shell: false,
+          input: fs.readFileSync(path.resolve('app/templates/application.hbs')),
+        });
 
         expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -96,7 +96,9 @@ describe('ember-template-lint executable', function () {
         `);
       });
     });
+  });
 
+  describe('reading files', function () {
     describe('given path to non-existing file', function () {
       it('should exit without error and any console output', async function () {
         setProjectConfigForErrors();

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -195,7 +195,7 @@ describe('ember-template-lint executable', function () {
         let result = await run(
           ['--filename', 'app/templates/application.hbs', '<', 'app/templates/application.hbs'],
           {
-            shell: false,
+            shell: true,
           }
         );
 

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -147,6 +147,19 @@ describe('ember-template-lint executable', function () {
       });
     });
 
+    describe('given path to single file without errors', function () {
+      it('should exit without error and any console output', async function () {
+        setProjectConfigWithoutErrors();
+        let result = await run(['app/templates/application.hbs']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toBeFalsy();
+        expect(result.stderr).toBeFalsy();
+      });
+    });
+  });
+
+  describe('reading from stdin', function () {
     describe('given no path', function () {
       it('should print errors', async function () {
         setProjectConfigForErrors();
@@ -234,17 +247,6 @@ describe('ember-template-lint executable', function () {
 
         expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();
-        expect(result.stderr).toBeFalsy();
-      });
-    });
-
-    describe('given path to single file without errors', function () {
-      it('should exit without error and any console output', async function () {
-        setProjectConfigWithoutErrors();
-        let result = await run(['app/templates/application.hbs']);
-
-        expect(result.exitCode).toEqual(0);
-        expect(result.stdout).toBeFalsy();
         expect(result.stderr).toBeFalsy();
       });
     });

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -875,7 +875,7 @@ describe('ember-template-lint executable', function () {
     });
   });
 
-  describe('--fix usage', function () {
+  describe('autofixing files', function () {
     it('should write fixed file to fs', async function () {
       let config = { rules: { 'require-button-type': true } };
       project.setConfig(config);

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -101,7 +101,7 @@ describe('ember-template-lint executable', function () {
   describe('reading files', function () {
     describe('given path to non-existing file', function () {
       it('should exit without error and any console output', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run(['app/templates/application-1.hbs']);
 
         expect(result.exitCode).toEqual(0, 'exits without error');
@@ -112,7 +112,7 @@ describe('ember-template-lint executable', function () {
 
     describe('given path to single file with errors', function () {
       it('should print errors', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run(['app/templates/application.hbs']);
 
         expect(result.exitCode).toEqual(1);
@@ -123,7 +123,7 @@ describe('ember-template-lint executable', function () {
 
     describe('given wildcard path resolving to single file', function () {
       it('should print errors', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run(['app/templates/*']);
 
         expect(result.exitCode).toEqual(1);
@@ -134,7 +134,7 @@ describe('ember-template-lint executable', function () {
 
     describe('given directory path', function () {
       it('should print errors', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run(['app']);
 
         expect(result.exitCode).toEqual(1);
@@ -164,7 +164,7 @@ describe('ember-template-lint executable', function () {
   describe('reading from stdin', function () {
     describe('given no path', function () {
       it('should print errors', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run([], {
           shell: false,
           input: fs.readFileSync(path.resolve('app/templates/application.hbs')),
@@ -205,7 +205,7 @@ describe('ember-template-lint executable', function () {
 
     describe('given no path with --filename', function () {
       it('should print errors', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run(['--filename', 'app/templates/application.hbs'], {
           shell: false,
           input: fs.readFileSync(path.resolve('app/templates/application.hbs')),
@@ -224,7 +224,7 @@ describe('ember-template-lint executable', function () {
       }
 
       it('should print errors', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run(['-', '<', 'app/templates/application.hbs'], {
           shell: true,
         });
@@ -242,7 +242,7 @@ describe('ember-template-lint executable', function () {
       }
 
       it('should print errors', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run(['/dev/stdin', '<', 'app/templates/application.hbs'], {
           shell: true,
         });
@@ -257,7 +257,7 @@ describe('ember-template-lint executable', function () {
   describe('errors and warnings formatting', function () {
     describe('without --json param', function () {
       it('should print properly formatted error messages', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run(['.']);
 
         expect(result.exitCode).toEqual(1);
@@ -518,7 +518,7 @@ describe('ember-template-lint executable', function () {
 
     describe('with --json param', function () {
       it('should print valid JSON string with errors', async function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrors(project);
         let result = await run(['--json', '.']);
 
         let expectedOutputData = {};
@@ -715,7 +715,7 @@ describe('ember-template-lint executable', function () {
 
       describe('given a directory with errors but a lintrc without any rules', function () {
         it('should exit without error and any console output', async function () {
-          setProjectConfigForErrors();
+          setProjectConfigForErrors(project);
 
           let overrideConfig = {
             rules: {
@@ -895,26 +895,6 @@ describe('ember-template-lint executable', function () {
     });
   });
 
-  // set specific project configuration for test cases.
-  function setProjectConfigForErrors() {
-    project.setConfig({
-      rules: {
-        'no-bare-strings': true,
-      },
-    });
-
-    project.write({
-      app: {
-        templates: {
-          'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
-          components: {
-            'foo.hbs': '{{fooData}}',
-          },
-        },
-      },
-    });
-  }
-
   function setProjectConfigWithoutErrors() {
     project.setConfig({
       rules: {
@@ -964,3 +944,23 @@ describe('ember-template-lint executable', function () {
     );
   }
 });
+
+// set specific project configuration for test cases.
+function setProjectConfigForErrors(project) {
+  project.setConfig({
+    rules: {
+      'no-bare-strings': true,
+    },
+  });
+
+  project.write({
+    app: {
+      templates: {
+        'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+        components: {
+          'foo.hbs': '{{fooData}}',
+        },
+      },
+    },
+  });
+}

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -7,6 +7,7 @@ const path = require('path');
 
 const Project = require('../helpers/fake-project');
 const setupEnvVar = require('../helpers/setup-env-var');
+const { setProjectConfigForErrors } = require('../helpers/set-config');
 
 describe('ember-template-lint executable', function () {
   setupEnvVar('GITHUB_ACTIONS', null);
@@ -944,23 +945,3 @@ describe('ember-template-lint executable', function () {
     );
   }
 });
-
-// set specific project configuration for test cases.
-function setProjectConfigForErrors(project) {
-  project.setConfig({
-    rules: {
-      'no-bare-strings': true,
-    },
-  });
-
-  project.write({
-    app: {
-      templates: {
-        'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
-        components: {
-          'foo.hbs': '{{fooData}}',
-        },
-      },
-    },
-  });
-}

--- a/test/acceptance/editors-integration-test.js
+++ b/test/acceptance/editors-integration-test.js
@@ -2,6 +2,8 @@
 const execa = require('execa');
 const Project = require('../helpers/fake-project');
 const setupEnvVar = require('../helpers/setup-env-var');
+const fs = require('fs');
+const path = require('path');
 
 function setForBasicDebuggerError(project) {
   project.setConfig({ rules: { 'no-debugger': true } });
@@ -39,13 +41,10 @@ describe('editors integration', function () {
     it('prints valid JSON strings with error', async function () {
       setForBasicDebuggerError(project);
 
-      let result = await run(
-        project,
-        ['--json', '--filename', 'template.hbs', '<', 'template.hbs'],
-        {
-          shell: false,
-        }
-      );
+      let result = await run(project, ['--json', '--filename', 'template.hbs'], {
+        shell: false,
+        input: fs.readFileSync(path.resolve('template.hbs')),
+      });
 
       let expectedOutputData = {};
       expectedOutputData['template.hbs'] = [

--- a/test/acceptance/stdin-by-platform-test.js
+++ b/test/acceptance/stdin-by-platform-test.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const execa = require('execa');
+const Project = require('../helpers/fake-project');
+const setupEnvVar = require('../helpers/setup-env-var');
+const { setProjectConfigForErrors } = require('../helpers/set-config');
+
+describe('ember-template-lint executable', function () {
+  setupEnvVar('GITHUB_ACTIONS', null);
+  setupEnvVar('FORCE_COLOR', '0');
+  setupEnvVar('LC_ALL', 'en_US');
+
+  // Fake project
+  let project;
+  beforeEach(function () {
+    project = Project.defaultSetup();
+    project.chdir();
+    setProjectConfigForErrors(project);
+  });
+
+  afterEach(async function () {
+    await project.dispose();
+  });
+
+  if (process.platform === 'win32') {
+    describe('in Windows Command Prompt', function () {
+      describe('command: `node ember-template-lint --filename template.hbs < template.hbs`', function () {
+        it('reports errors to stdout', async function () {
+          let result = await execa(
+            process.execPath,
+            [
+              require.resolve('../../bin/ember-template-lint.js'),
+              '--filename',
+              'app/templates/application.hbs',
+              '<',
+              'app/templates/application.hbs',
+            ],
+            {
+              shell: true,
+              reject: false,
+              cwd: project.path('.'),
+            }
+          );
+
+          expect(result.stdout).toMatchInlineSnapshot(`
+            "app/templates/application.hbs
+              1:4  error  Non-translated string used  no-bare-strings
+              1:25  error  Non-translated string used  no-bare-strings
+
+            ✖ 2 problems (2 errors, 0 warnings)"
+          `);
+          expect(result.stderr).toBeFalsy();
+        });
+      });
+    });
+  }
+
+  if (process.platform === 'linux' || process.platform === 'darwin') {
+    describe('in unix bash', function () {
+      describe('command: `cat template.hbs | ember-template-lint --filename template.hbs`', function () {
+        it('has exit code 1 and reports errors to stdout', async function () {
+          let result = await execa(
+            'cat',
+            [
+              'app/templates/application.hbs',
+              '|',
+              require.resolve('../../bin/ember-template-lint.js'),
+              '--filename',
+              'app/templates/application.hbs',
+            ],
+            {
+              shell: true,
+              reject: false,
+              cwd: project.path('.'),
+            }
+          );
+
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout).toMatchInlineSnapshot(`
+            "app/templates/application.hbs
+              1:4  error  Non-translated string used  no-bare-strings
+              1:25  error  Non-translated string used  no-bare-strings
+
+            ✖ 2 problems (2 errors, 0 warnings)"
+          `);
+          expect(result.stderr).toBeFalsy();
+        });
+      });
+
+      describe('command: `cat template.hbs | ember-template-lint --filename template.hbs -`', function () {
+        it('has exit code 1 and reports errors to stdout', async function () {
+          let result = await execa(
+            'cat',
+            [
+              'app/templates/application.hbs',
+              '|',
+              require.resolve('../../bin/ember-template-lint.js'),
+              '--filename',
+              'app/templates/application.hbs',
+              '-',
+            ],
+            {
+              shell: true,
+              reject: false,
+              cwd: project.path('.'),
+            }
+          );
+
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout).toMatchInlineSnapshot(`
+            "app/templates/application.hbs
+              1:4  error  Non-translated string used  no-bare-strings
+              1:25  error  Non-translated string used  no-bare-strings
+
+            ✖ 2 problems (2 errors, 0 warnings)"
+          `);
+          expect(result.stderr).toBeFalsy();
+        });
+      });
+
+      describe('command: `ember-template-lint --filename template.hbs < template.hbs`', function () {
+        it('has exit code 1 and reports errors to stdout', async function () {
+          let result = await execa(
+            require.resolve('../../bin/ember-template-lint.js'),
+            ['--filename', 'app/templates/application.hbs', '<', 'app/templates/application.hbs'],
+            {
+              shell: true,
+              reject: false,
+              cwd: project.path('.'),
+            }
+          );
+
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout).toMatchInlineSnapshot(`
+            "app/templates/application.hbs
+              1:4  error  Non-translated string used  no-bare-strings
+              1:25  error  Non-translated string used  no-bare-strings
+
+            ✖ 2 problems (2 errors, 0 warnings)"
+          `);
+          expect(result.stderr).toBeFalsy();
+        });
+      });
+    });
+  }
+});

--- a/test/helpers/set-config.js
+++ b/test/helpers/set-config.js
@@ -1,0 +1,22 @@
+function setProjectConfigForErrors(project) {
+  project.setConfig({
+    rules: {
+      'no-bare-strings': true,
+    },
+  });
+
+  project.write({
+    app: {
+      templates: {
+        'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+        components: {
+          'foo.hbs': '{{fooData}}',
+        },
+      },
+    },
+  });
+}
+
+module.exports = {
+  setProjectConfigForErrors,
+};

--- a/test/helpers/set-config.js
+++ b/test/helpers/set-config.js
@@ -17,6 +17,47 @@ function setProjectConfigForErrors(project) {
   });
 }
 
+function setProjectConfigForErrorsAndWarning(project) {
+  project.setConfig({
+    rules: {
+      'no-bare-strings': true,
+      'no-html-comments': true,
+    },
+    pending: [
+      {
+        moduleId: 'app/templates/application',
+        only: ['no-html-comments'],
+      },
+    ],
+  });
+  project.write({
+    app: {
+      templates: {
+        'application.hbs':
+          '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+      },
+    },
+  });
+}
+
+function setProjectConfigWithoutErrors(project) {
+  project.setConfig({
+    rules: {
+      'no-bare-strings': false,
+    },
+  });
+
+  project.write({
+    app: {
+      templates: {
+        'application.hbs': '<h2>Love for bare strings!!!</h2> <div>Bare strings are great!</div>',
+      },
+    },
+  });
+}
+
 module.exports = {
   setProjectConfigForErrors,
+  setProjectConfigForErrorsAndWarning,
+  setProjectConfigWithoutErrors,
 };


### PR DESCRIPTION
- create a "reading stdin" describe in `test/acceptance/cli`
- create `test/acceptance/stdin-by-platform` to test platform-specific stdin redirections
- document platform-specific stdin redirections in README
- extract helpers functions shared between acceptance tests